### PR TITLE
make GroupDetailsScreen test deterministic

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "loki": {
     "diffingEngine": "looks-same",
     "reactUri": "file:./storybook-static",
-    "chromeTolerance": 20,
+    "chromeTolerance": 40,
     "configurations": {
       "iphone7": {
         "target": "chrome.docker",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@expo/react-native-action-sheet": "^2.1.0",
     "apollo-boost": "^0.3.1",
     "apollo-link-context": "^1.0.15",
-    "apollo-link-ws": "^1.0.15",
+    "apollo-link-ws": "^1.0.16",
     "apollo-utilities": "^1.1.3",
     "expo": "^32.0.6",
     "formik": "^1.5.1",

--- a/src/components/screens/GroupDetailsScreen.tsx
+++ b/src/components/screens/GroupDetailsScreen.tsx
@@ -2,8 +2,7 @@ import hoistNonReactStatics from "hoist-non-react-statics";
 import { inflect } from "inflection";
 import { remove } from "lodash";
 import * as React from "react";
-import { Alert, ScrollView, StyleSheet } from "react-native";
-import { Image } from "react-native-elements";
+import { Alert, ScrollView, StyleSheet, View } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 
 import { getGroups, getGroups_groups } from "../../generated/getGroups";
@@ -56,7 +55,7 @@ class GroupDetailsScreen extends React.PureComponent<IGroupDetailsScreen> {
       const members = group.members || [];
       return (
         <ScrollView style={style.container}>
-          <Image source={{ uri: "https://placeimg.com/600/200/nature" }} style={style.groupImage} />
+          <View style={style.groupImage} />
           <EditableTextView onPress={this.openEditNameModal}>
             <WobblyText title1={true}>{group.name}</WobblyText>
           </EditableTextView>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,23 +2323,23 @@ apollo-link-schema@^1.1.6:
     apollo-link "^1.2.9"
     tslib "^1.9.3"
 
-apollo-link-ws@^1.0.15, apollo-link-ws@^1.0.9:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/apollo-link-ws/-/apollo-link-ws-1.0.15.tgz#1a0132ee3c700640d64c5b00ad8cff5cb974ff62"
-  integrity sha512-zXYfvKBpgf7QXIIEO11qgKLYyodo1mDkJr2IojcvOqbGGtqi7+DtOxX21/mrM2pzcwczYGCSDrtFhas4A7RnNA==
+apollo-link-ws@^1.0.16, apollo-link-ws@^1.0.9:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/apollo-link-ws/-/apollo-link-ws-1.0.16.tgz#f4075c0913b287ad79c73b7339395e43de19c406"
+  integrity sha512-uiR44CypjGMGza91t1q+XhWKOw6U7F9lPu47cQDDPrfyNG73pYX6MbE/9tZFAIl3eWnAO17TTpxzNTWfpIhODA==
   dependencies:
-    apollo-link "^1.2.9"
+    apollo-link "^1.2.10"
     tslib "^1.9.3"
 
-apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.3, apollo-link@^1.2.9:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.9.tgz#40a8f0b90716ce3fd6beb27b7eae1108b92e0054"
-  integrity sha512-ZLUwthOFZq4lxchQ2jeBfVqS/UDdcVmmh8aUw6Ar9awZH4r+RgkcDeu2ooFLUfodWE3mZr7wIZuYsBas/MaNVA==
+apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.10, apollo-link@^1.2.3, apollo-link@^1.2.9:
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.10.tgz#98cf24c46c0d75cb878804143e39dcf9813f0c20"
+  integrity sha512-vQ5u+jEHyLJaV+eUoVKFYYiJcCY9dBNSNhf7Ve9YxeFf84ZDt5NNOPXQEygF39qdoqFRYJb7OkAOJptydteOvw==
   dependencies:
     apollo-utilities "^1.2.1"
     ts-invariant "^0.3.2"
     tslib "^1.9.3"
-    zen-observable-ts "^0.8.16"
+    zen-observable-ts "^0.8.17"
 
 apollo-server-caching@0.2.2:
   version "0.2.2"
@@ -12954,10 +12954,10 @@ yup@^0.26.10:
     synchronous-promise "^2.0.5"
     toposort "^2.0.2"
 
-zen-observable-ts@^0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.16.tgz#969367299074fe17422fe2f46ee417e9a30cf3fa"
-  integrity sha512-pQl75N7qwgybKVsh6WFO+WwPRijeQ52Gn1vSf4uvPFXald9CbVQXLa5QrOPEJhdZiC+CD4quqOVqSG+Ptz5XLA==
+zen-observable-ts@^0.8.17:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.17.tgz#b3183625fa55d3960c829e3a90061f82ec2d7863"
+  integrity sha512-eVQH3UG5h4lMlD9HMMIsiMk3vsCW66QVOPJQMCSJhP4THswDW7r/BPHO6oCZbA/LZzntv2t8W/bv3vYO9NYh/g==
   dependencies:
     tslib "^1.9.3"
     zen-observable "^0.8.0"


### PR DESCRIPTION
Previously, this used a random image which caused snapshot tests to fail. This removes the placeholder image so that the screen show empty state for the image until the backend supports specifying an image for the group